### PR TITLE
Add --bits option and pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ use this component for whatever purpose.
 | frag:scale  _scale_          | Canvas is scaled on screen by this factor. |
 | frag:fps    _fps_            | Maximum frames per second.                 |
 | frag:wrap   _mode_           | Wrapping mode when sampling from canvas. `repeat`, `mirror` or `clamp`. |
+| frag:bits   _bits_           | Bit depth of pixel. 32 or 64.              |
 
 The canvas size etc. can also be set via command-line options:
 

--- a/frag.go
+++ b/frag.go
@@ -11,6 +11,7 @@ type Frag struct {
 	Scale    float64
 	FPS      float64
 	WrapMode int32
+	PixType  uint32
 	Filename string
 	Source   string
 	NoResize bool
@@ -20,6 +21,11 @@ const (
 	WrapRepeat = gl.REPEAT
 	WrapMirror = gl.MIRRORED_REPEAT
 	WrapClamp  = gl.CLAMP_TO_EDGE
+)
+
+const (
+	Pix32 = gl.UNSIGNED_BYTE
+	Pix64 = gl.UNSIGNED_SHORT
 )
 
 const (
@@ -69,6 +75,7 @@ func (f *Frag) Run() error {
 		CanvasSize:   size{f.Width, f.Height},
 		ViewportSize: size{viewportWidth, viewportHeight},
 		WrapMode:     f.WrapMode,
+		PixType:      f.PixType,
 		FragShader:   f.Source,
 	})
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -20,6 +20,7 @@ options:
   -x, --scale <scale>  Display scale of the canvas
   -f, --fps <fps>      Maximum number of frames per second
   -w, --wrap <mode>    Wrap mode (repeat or mirror)
+  -b, --bits <bits>    Bit depth of pixel (32 or 64)
   --noresize           Do not allow resizing window
   -h, --help           Print usage message and exit
 `
@@ -30,6 +31,7 @@ var defaultFrag = frag.Frag{
 	Scale:    1.0,
 	FPS:      60.0,
 	WrapMode: frag.WrapRepeat,
+	PixType:  frag.Pix32,
 }
 
 func init() {
@@ -90,6 +92,15 @@ func run() error {
 		}
 
 		frag.Scale = scale
+	}
+
+	if bitsSpec, ok := opts["--bits"].(string); ok {
+		pixType, err := parsePixType(bitsSpec)
+		if err != nil {
+			return err
+		}
+
+		frag.PixType = pixType
 	}
 
 	if fpsSpec, ok := opts["--fps"].(string); ok {

--- a/main/parse.go
+++ b/main/parse.go
@@ -14,6 +14,7 @@ var (
 	errScale        = errors.New("invalid scale")
 	errFPS          = errors.New("invalid FPS")
 	errWrapMode     = errors.New("invalid wrap mode")
+	errPixType      = errors.New("invalid bit depth")
 )
 
 func parseCanvas(s string) (int, int, error) {
@@ -87,4 +88,16 @@ func parseWrapMode(s string) (int32, error) {
 	}
 
 	return 0, errWrapMode
+}
+
+func parsePixType(s string) (uint32, error) {
+	switch s {
+	case "32":
+		return frag.Pix32, nil
+
+	case "64":
+		return frag.Pix64, nil
+	}
+
+	return 0, errPixType
 }

--- a/main/pragmas.go
+++ b/main/pragmas.go
@@ -49,6 +49,13 @@ func parsePragma(source string, frag *frag.Frag) error {
 			}
 			frag.WrapMode = mode
 
+		case "bits":
+			pixType, err := parsePixType(value)
+			if err != nil {
+				return err
+			}
+			frag.PixType = pixType
+
 		default:
 		}
 	}

--- a/scene.go
+++ b/scene.go
@@ -70,6 +70,7 @@ type sceneConfig struct {
 	CanvasSize   size
 	ViewportSize size
 	WrapMode     int32
+	PixType      uint32
 	FragShader   string
 }
 
@@ -170,7 +171,7 @@ func (s *scene) initFramebuffer(c sceneConfig) error {
 			int32(c.CanvasSize.Y),
 			0,
 			gl.RGBA,
-			gl.UNSIGNED_BYTE,
+			c.PixType,
 			nil,
 		)
 


### PR DESCRIPTION
Shader reads and writes floating-point color values but actual pixels are stored in 8-bits format. This inaccuracy may cause numerical problem when rendering some stateful scene.